### PR TITLE
fix(docs): update profiles config format from list to map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,14 +35,23 @@ This is a Go-based Claude Code Adapter that acts as a proxy server, converting b
 ## Architecture
 
 ### Server Operation
-The server (`cmd/claude-code-adapter-cli/serve.go`) operates as an HTTP proxy listening on port 2194 (default). It routes requests based on provider configuration (`openrouter` or `anthropic`) and handles format conversion.
+The server (`cmd/claude-code-adapter-cli/serve.go`) operates as an HTTP proxy listening on port 2194 (default). It routes requests based on profile matching and handles format conversion.
 
 ### Core Components
+- **Profile System** (`pkg/profile`): Model-to-configuration matching using prefix patterns (e.g., `claude-*`). First matching profile wins. See `config.template.yaml` for examples.
 - **Provider Interface** (`pkg/provider`): Defines API interfaces using `defc` annotations. `provider_impl.go` is auto-generated.
 - **Format Adapter** (`pkg/adapter/convert_request.go`): Converts Anthropic requests to OpenRouter format. Handles model mapping, tool calls, and thinking mode.
 - **Stream Adapter** (`pkg/adapter/convert_stream.go`): Converts OpenRouter streaming responses to Anthropic streaming format. Handles event sequencing and content type transitions.
 - **Data Types** (`pkg/datatypes`): Definitions for Anthropic (`pkg/datatypes/anthropic`) and OpenRouter (`pkg/datatypes/openrouter`) APIs.
 - **Snapshot** (`pkg/snapshot`): Records request/response pairs to JSONL for debugging/auditing.
+
+### Profile-Based Configuration
+Profiles are defined as a map in `config.yaml`. Each profile specifies:
+- `models`: List of patterns to match (supports `*` suffix for prefix matching)
+- `provider`: Target provider (`openrouter` or `anthropic`)
+- `options`, `anthropic`, `openrouter`: Provider-specific settings
+
+Profile order in YAML determines matching priority. The `ProfileManager` iterates profiles in definition order and returns the first match.
 
 ### Code Generation
 - Uses `github.com/x5iu/defc` to generate HTTP clients.

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -18,9 +18,10 @@ http:
 # Models are matched using prefix patterns (e.g., "claude-*" matches all Claude models).
 # When a request comes in, the adapter finds the first matching profile for the model.
 # If no profile matches, a 400 error is returned.
+# Note: Profile order matters - first matching profile wins. Define in YAML order.
 profiles:
   # Profile for Claude models using Anthropic provider
-  - name: "anthropic-claude"
+  anthropic-claude:
     # Model patterns to match (supports "*" suffix for prefix matching)
     models:
       - "claude-*"
@@ -84,7 +85,7 @@ profiles:
       allowed_providers: []
 
   # Profile for Claude models using OpenRouter provider (as fallback/alternative)
-  - name: "openrouter-claude"
+  openrouter-claude:
     models:
       - "anthropic/claude-*"
     provider: "openrouter"
@@ -125,7 +126,7 @@ profiles:
         - "amazon-bedrock"
 
   # Profile for OpenAI models (GPT-5, etc.)
-  - name: "openrouter-openai"
+  openrouter-openai:
     models:
       - "openai/*"
       - "gpt-*"
@@ -160,7 +161,7 @@ profiles:
       allowed_providers: []
 
   # Profile for Google Gemini models
-  - name: "openrouter-gemini"
+  openrouter-gemini:
     models:
       - "google/*"
       - "gemini-*"
@@ -196,7 +197,7 @@ profiles:
         - "google-vertex"
 
   # Default catch-all profile (matches any model not matched by previous profiles)
-  - name: "default"
+  default:
     models:
       - "*"
     provider: "openrouter"


### PR DESCRIPTION
## Summary
- Fixed `config.template.yaml` to use map format for profiles instead of list format (matching the actual code structure in `pkg/profile/config.go`)
- Updated `README.md` with correct profile-based configuration examples
- Updated `CLAUDE.md` to document the Profile System architecture

## Test plan
- [ ] Verify `config.template.yaml` can be loaded correctly by the adapter
- [ ] Review documentation for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)