### PR TITLE
feat(options): add min_max_tokens option to enforce minimum max_tokens value

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -36,6 +36,9 @@ profiles:
       # Prevent empty text in tool_result by replacing it with "(No content)".
       # Some providers (like OpenAI) may reject empty content in tool results.
       prevent_empty_text_tool_result: false
+      # Minimum value for max_tokens. If the request's max_tokens is less than this value,
+      # it will be raised to this minimum. Set to 0 to disable (default).
+      min_max_tokens: 0
       reasoning:
         # Default reasoning detail format when not overridden per-model.
         # "anthropic-claude-v1" for Anthropic-style reasoning; "openai-responses-v1" for OpenAI Responses v1;

--- a/pkg/adapter/convert_request.go
+++ b/pkg/adapter/convert_request.go
@@ -27,9 +27,13 @@ func ConvertAnthropicRequestToOpenRouterRequest(
 	for _, applyOption := range options {
 		applyOption(convertOptions)
 	}
+	maxTokens := src.MaxTokens
+	if minMaxTokens := prof.Options.GetMinMaxTokens(); minMaxTokens > 0 && maxTokens < minMaxTokens {
+		maxTokens = minMaxTokens
+	}
 	dst = &openrouter.CreateChatCompletionRequest{
 		Model:       src.Model,
-		MaxTokens:   lo.ToPtr(src.MaxTokens),
+		MaxTokens:   lo.ToPtr(maxTokens),
 		Temperature: lo.ToPtr(src.Temperature),
 		TopK:        src.TopK,
 		TopP:        src.TopP,

--- a/pkg/profile/config.go
+++ b/pkg/profile/config.go
@@ -147,6 +147,7 @@ func loadOptionsConfig(v *viper.Viper, key string) *OptionsConfig {
 		Models:                     v.GetStringMapString(delimiter.ViperKey(key, "models")),
 		ContextWindowResizeFactor:  v.GetFloat64(delimiter.ViperKey(key, "context_window_resize_factor")),
 		DisableCountTokensRequest:  v.GetBool(delimiter.ViperKey(key, "disable_count_tokens_request")),
+		MinMaxTokens:               v.GetInt(delimiter.ViperKey(key, "min_max_tokens")),
 	}
 }
 
@@ -267,6 +268,15 @@ func (o *OptionsConfig) GetReasoningDelimiter() string {
 		return "/"
 	}
 	return o.Reasoning.Delimiter
+}
+
+// GetMinMaxTokens safely gets the minimum max_tokens value.
+// Returns 0 if not set (meaning no minimum enforcement).
+func (o *OptionsConfig) GetMinMaxTokens() int {
+	if o == nil {
+		return 0
+	}
+	return o.MinMaxTokens
 }
 
 // GetBaseURL safely gets the Anthropic base URL with a default.

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -30,6 +30,7 @@ type OptionsConfig struct {
 	Models                     map[string]string `yaml:"models" json:"models" mapstructure:"models"`
 	ContextWindowResizeFactor  float64           `yaml:"context_window_resize_factor" json:"context_window_resize_factor" mapstructure:"context_window_resize_factor"`
 	DisableCountTokensRequest  bool              `yaml:"disable_count_tokens_request" json:"disable_count_tokens_request" mapstructure:"disable_count_tokens_request"`
+	MinMaxTokens               int               `yaml:"min_max_tokens" json:"min_max_tokens" mapstructure:"min_max_tokens"`
 }
 
 // ReasoningConfig contains options for reasoning/thinking mode.


### PR DESCRIPTION
## Summary
- Add `min_max_tokens` configuration option to `profile.options`
- When set, ensures the request's `max_tokens` is never less than the configured minimum
- Useful for providers that require a minimum token budget

## Changes
- `pkg/profile/profile.go`: Add `MinMaxTokens` field to `OptionsConfig`
- `pkg/profile/config.go`: Load `min_max_tokens` from config and add `GetMinMaxTokens()` getter
- `pkg/adapter/convert_request.go`: Apply minimum max_tokens logic during request conversion
- `config.template.yaml`: Document the new option

## Usage
```yaml
profiles:
  my-profile:
    options:
      min_max_tokens: 1024  # max_tokens will be at least 1024
```

## Test plan
- [ ] Verify `go vet ./...` passes
- [ ] Test with `min_max_tokens: 0` (disabled, default behavior)
- [ ] Test with `min_max_tokens: 1024` and request with `max_tokens: 512` (should be raised to 1024)
- [ ] Test with `min_max_tokens: 1024` and request with `max_tokens: 2048` (should remain 2048)

🤖 Generated with [Claude Code](https://claude.com/claude-code)